### PR TITLE
Improve performance of creating and filling a vector in line 56 of src/main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,8 @@ fn kernel_main(bootinfo: &'static BootInfo) -> !
 	let heap_value = Box::new(41);
 	println!("[INFO] HEAP_VALUE AT {:p}", heap_value);
 
-	let mut vec = Vec::new();
-	for i in 0..500
-	{
-		vec.push(i);
-	}
+	let mut vec = (0..500).collect::<Vec<i32>>();
+	
 	println!("[INFO] VEC AT {:p}", vec.as_slice());
 
 	let refcounted = Rc::new(vec![1, 2, 3]);


### PR DESCRIPTION
[In line 56 of src/main.rs](https://github.com/LibertyOS-Development/kernel/blob/main/src/main.rs#:~:text=let%20mut%20vec,%7D) there is an inefficient creation and population of a vector. This pull request improves this by creating and populating the vector with iterator collect instead of a for loop which pushes a number onto vector with each iteration.
This optimization was originally noticed by reddit user [NateReinarWoodwind](https://www.reddit.com/r/rust/comments/rgpdd7/comment/hommezy/?utm_source=share&utm_medium=web2x&context=3).