### PR TITLE
Rust 1.59 support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Download Rust toolchain
+      uses: hermitcore/toolchain@downstream
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ memoffset = "0.6.4"
 num-traits = { version = "0.2.14", default-features = false }
 object = { version = "0.27.1", default-features = false }
 pc-keyboard = "0.5.0"
-x86_64 = "0.14.2"
+x86_64 = "0.14.7"
 rand = { version = "0.8.4", default-features = false }
 rand_core = { version = "0.6.3", default-features = false }
 raw-cpuid = "10.2.0"
@@ -36,7 +36,7 @@ uart_16550 = "0.2.0"
 volatile = "0.2.6"
 vga = "0.2.7"
 vte = "0.10.1"
-#x86 = "0.43.0"
+#x86 = "0.44.0"
 
 [dependencies.crossbeam-queue]
 version = "0.2.1"
@@ -59,7 +59,6 @@ test-args = [
 	    ]
 test-success-exit-code = 33
 test-timeout = 300
-
 
 [[test]]
 name = "shouldpanic"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 clear
 
 echo " _     _ _               _          ___  ____  "
@@ -9,15 +9,13 @@ echo "|_____|_|_.__/ \___|_|   \__|\__, |\___/|____/ "
 echo "                             |___/             "
 echo "By using this script, and by running LibertyOS, you are agreeing to the terms outlined in the LICENSE."
 echo "Installing rustup..."
+if ! rustc --version; then
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-echo "Installing libraries for x86_64-unknown-linux-gnu..."
-rustup target add x86_64-unknown-linux-gnu
-echo "Installing the llvm-tools-preview component..."
-rustup component add llvm-tools-preview
+else
+echo "Rust already installed"
+fi
 echo "Installing the bootimage crate..."
 cargo install bootimage
-echo "Setting the default Rust toolchain to the nightly build..."
-rustup default nightly
 echo "Your system should now be correctly configured to build and run LibertyOS."
 echo "To launch the kernel in a VM, use the cargo run command (requires QEMU)"
 echo "To compile LibertyOS, for use in another VM software, or to run LibertyOS on real hardware, simply use the cargo build command."

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2022-01-07"
+components = [ "rust-src", "clippy", "rustfmt", "rustc", "rust-std", "llvm-tools-preview" ]
+targets = [ "x86_64-unknown-linux-gnu" ]


### PR DESCRIPTION
There have been some changes in Rust 1.59 to stabilize the asm feature that now require action from crate users. This PR resolves them