### PR TITLE
Bump rust nightly version, fix memory assertion error

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,6 @@ target = "x86_64-libertyos.json"
 
 [target.'cfg(target_os = "none")']
 runner = "bootimage runner"
+
+[registries.crates-io]
+protocol = "sparse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "d73c55835cc76243c11580a55eff3f31250b00105a744015b8957ed4203fb8ad"
 
 [[package]]
 name = "bootloader"
-version = "0.9.21"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62c8f6168cd106687ee36a2b71a46c4144d73399f72814104d33094b8092fd2"
+checksum = "b6e02311b16c9819e7c72866d379cdd3026c3b7b25c1edf161f548f8e887e7ff"
 
 [[package]]
 name = "byteorder"
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "libertyos_kernel"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "acpi",
  "aml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ aml = "0.16.0"
 arrayvec = { version = "0.7.2", default-features = false }
 bit_field = "0.10.1"
 bitflags = "1.3.2"
-bootloader = { version = "0.9.9", features = ["map_physical_memory"]}
+bootloader = { version = "0.9.23", features = ["map_physical_memory"]}
 conquer-once = { version = "0.2.0", default-features = false }
 embedded-graphics = "0.7.1"
 embedded-graphics-framebuf = "0.2.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-01-07"
+channel = "nightly-2023-01-21"
 components = [ "rust-src", "clippy", "rustfmt", "rustc", "rust-std", "llvm-tools-preview" ]
 targets = [ "x86_64-unknown-linux-gnu" ]


### PR DESCRIPTION
This PR updates rust nightly version to `1.68.0(2023-01-21)`, introducing the sparse registry protocol which should significantly improve the initially compile time by reducing the time required to index `crates.io`.

It also fixes the issue #19 by bumping the version for `bootloader` crate to `v0.9.23`.